### PR TITLE
Add options for the bitcoind backend

### DIFF
--- a/docker/lnd/start-lnd.sh
+++ b/docker/lnd/start-lnd.sh
@@ -41,6 +41,7 @@ set_default() {
 # Set default variables if needed.
 PUBLICIP=$(set_default "$PUBLICIP" "127.0.0.1")
 LISTEN=$(set_default "$LISTEN" "9735")
+RPCHOST=$(set_default "$RPCHOST" "localhost:8332")
 RPCUSER=$(set_default "$RPCUSER" "devuser")
 RPCPASS=$(set_default "$RPCPASS" "devpass")
 DEBUG=$(set_default "$DEBUG" "debug")
@@ -52,6 +53,8 @@ RESTLISTEN=$(set_default "$RESTLISTEN" "8080")
 RPCLISTEN=$(set_default "$RPCLISTEN" "10009")
 MONITORLISTEN=$(set_default "$MONITORLISTEN" "8989")
 CHAN_CONFS=$(set_default "$CHAN_CONFS" 3)
+ZMQPUBRAWBLOCK=$(set_default "$ZMQPUBRAWBLOCK" "tcp://localhost:28332")
+ZMQPUBRAWTX=$(set_default "$ZMQPUBRAWTX" "tcp://localhost:28333")
 
 PARAMS=$(echo $PARAMS \
     "--lnddir=$LND_DIR" \
@@ -82,6 +85,16 @@ fi
 
 if [[ "$CHAIN" == "litecoin" ]]; then
     BACKEND="ltcd"
+fi
+
+if [[ $BACKEND == "bitcoind" ]]; then
+    PARAMS=$(echo $PARAMS \
+        "--bitcoind.rpchost=$RPCHOST" \
+        "--bitcoind.rpcuser=$RPCUSER" \
+        "--bitcoind.rpcpass=$RPCPASS" \
+        "--bitcoind.zmqpubrawblock=$ZMQPUBRAWBLOCK" \
+        "--bitcoind.zmqpubrawtx=$ZMQPUBRAWTX"
+    )
 fi
 
 if [[ $BACKEND == "btcd" ]]; then

--- a/docker/lnd/start-lnd.sh
+++ b/docker/lnd/start-lnd.sh
@@ -98,7 +98,7 @@ fi
 
 if [[ $BACKEND == "bitcoind" ]]; then
     PARAMS=$(echo $PARAMS \
-        "--bitcoind.rpchost=$RPCHOST" \
+        "--bitcoind.rpchost=$BACKEND_RPC_HOST" \
         "--bitcoind.rpcuser=$RPCUSER" \
         "--bitcoind.rpcpass=$RPCPASS" \
         "--bitcoind.zmqpubrawblock=$BITCOIND_ZMQPUBRAWBLOCK" \
@@ -108,7 +108,7 @@ fi
 
 if [[ $BACKEND == "btcd" ]]; then
     PARAMS=$(echo $PARAMS \
-        "--btcd.rpchost=$RPCHOST" \
+        "--btcd.rpchost=$BACKEND_RPC_HOST" \
         "--btcd.rpccert=/rpc/rpc.cert" \
         "--btcd.rpcuser=$RPCUSER" \
         "--btcd.rpcpass=$RPCPASS"

--- a/docker/lnd/start-lnd.sh
+++ b/docker/lnd/start-lnd.sh
@@ -41,7 +41,6 @@ set_default() {
 # Set default variables if needed.
 PUBLICIP=$(set_default "$PUBLICIP" "127.0.0.1")
 LISTEN=$(set_default "$LISTEN" "9735")
-RPCHOST=$(set_default "$RPCHOST" "localhost:8332")
 RPCUSER=$(set_default "$RPCUSER" "devuser")
 RPCPASS=$(set_default "$RPCPASS" "devpass")
 DEBUG=$(set_default "$DEBUG" "debug")
@@ -53,8 +52,18 @@ RESTLISTEN=$(set_default "$RESTLISTEN" "8080")
 RPCLISTEN=$(set_default "$RPCLISTEN" "10009")
 MONITORLISTEN=$(set_default "$MONITORLISTEN" "8989")
 CHAN_CONFS=$(set_default "$CHAN_CONFS" 3)
-ZMQPUBRAWBLOCK=$(set_default "$ZMQPUBRAWBLOCK" "tcp://localhost:28332")
-ZMQPUBRAWTX=$(set_default "$ZMQPUBRAWTX" "tcp://localhost:28333")
+
+# For btcd and bitcoind
+RPCHOST=$(set_default "$RPCHOST" "blockchain")
+BACKEND_RPC_PORT=$(set_default "$BACKEND_RPC_PORT" "8332")
+BACKEND_RPC_HOST=$(set_default "$BACKEND_RPC_HOST" "$RPCHOST:$BACKEND_RPC_PORT")
+
+# For bitcoind
+BITCOIND_ZMQPUBRAWBLOCK_PORT=$(set_default "$BITCOIND_ZMQPUBRAWBLOCK_PORT" "28332")
+BITCOIND_ZMQPUBRAWTX_PORT=$(set_default "$BITCOIND_ZMQPUBRAWTX_PORT" "28333")
+BITCOIND_ZMQPUBRAWBLOCK=$(set_default "$BITCOIND_ZMQPUBRAWBLOCK" "tcp://$RPCHOST:$BITCOIND_ZMQPUBRAWBLOCK_PORT")
+BITCOIND_ZMQPUBRAWTX=$(set_default "$BITCOIND_ZMQPUBRAWTX" "tcp://$RPCHOST:$BITCOIND_ZMQPUBRAWTX")
+
 
 PARAMS=$(echo $PARAMS \
     "--lnddir=$LND_DIR" \
@@ -92,14 +101,14 @@ if [[ $BACKEND == "bitcoind" ]]; then
         "--bitcoind.rpchost=$RPCHOST" \
         "--bitcoind.rpcuser=$RPCUSER" \
         "--bitcoind.rpcpass=$RPCPASS" \
-        "--bitcoind.zmqpubrawblock=$ZMQPUBRAWBLOCK" \
-        "--bitcoind.zmqpubrawtx=$ZMQPUBRAWTX"
+        "--bitcoind.zmqpubrawblock=$BITCOIND_ZMQPUBRAWBLOCK" \
+        "--bitcoind.zmqpubrawtx=$BITCOIND_ZMQPUBRAWTX"
     )
 fi
 
 if [[ $BACKEND == "btcd" ]]; then
     PARAMS=$(echo $PARAMS \
-        "--btcd.rpchost=blockchain" \
+        "--btcd.rpchost=$RPCHOST" \
         "--btcd.rpccert=/rpc/rpc.cert" \
         "--btcd.rpcuser=$RPCUSER" \
         "--btcd.rpcpass=$RPCPASS"


### PR DESCRIPTION
Well, `localhost` as a default probably doesn't make too much sense in this case actually.

I guess something like `HOST=$(ip route | awk '/default/ { print $3 }')` could do the trick. Or assume that it's running in Docker / Swarm's overlay network and make the default host `bitcoind` / `backend` or something?

Then it can be used standalone with:
```
extra_hosts:
    - "bitcoind:$DOCKER_HOST_IP"
```

or in Swarm with a `bitcoind` service.